### PR TITLE
Fixed Spaetzle-Ticker for new Version of Speiseplan

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,9 +8,9 @@
         <meta charset="utf-8">
     </head>
 
-    <body onload="getNextSpaetzleDay()">
+    <body onload="get_spaetzle_days()">
         <div>
-            <p>Spätzle available on (up to 30 days): </p>
+            <p>Spätzle available on (up to 10 days): </p>
             <div id="spaetzle-counter"></div>
         </div>
     </body>


### PR DESCRIPTION
You can also optionally include a corsproxy key in the url params of this website to send the request with your key to prevent ratelimits (to bookmark it)
Looks like this now:
![grafik](https://github.com/user-attachments/assets/cb1723cf-ea20-48c4-809a-37d16d4dcf4f)
